### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ The total simultaneous connections the pool will allow is ``pool_size + max_over
 
 As an example, databases in the `Heroku Postgres <https://postgres.heroku.com>`_ starter tier have a maximum connection limit of 20. In that case your ``pool_size`` and ``max_overflow``, when combined, should not exceed 20.
 
-Check out the official `SQLAlchemy Connection Pooling <http://docs.sqlalchemy.org/en/latest/core/pooling.html#sqlalchemy.pool.QueuePool.__init__>`_ docs to learn more about the optoins that can be defined in ``DATABASE_POOL_ARGS``.
+Check out the official `SQLAlchemy Connection Pooling <http://docs.sqlalchemy.org/en/latest/core/pooling.html#sqlalchemy.pool.QueuePool.__init__>`_ docs to learn more about the options that can be defined in ``DATABASE_POOL_ARGS``.
 
 Django 1.3 Support
 ------------------

--- a/django_postgrespool/base.py
+++ b/django_postgrespool/base.py
@@ -53,7 +53,7 @@ def is_disconnect(e, connection, cursor):
                 'connection not open' in str(e) or \
                 'could not receive data from server' in str(e)
     elif isinstance(e, InterfaceError):
-        # psycopg2 client errors, psycopg2/conenction.h, psycopg2/cursor.h
+        # psycopg2 client errors, psycopg2/connection.h, psycopg2/cursor.h
         return 'connection already closed' in str(e) or \
                 'cursor already closed' in str(e)
     elif isinstance(e, ProgrammingError):


### PR DESCRIPTION
There are small typos in:
- README.rst
- django_postgrespool/base.py

Fixes:
- Should read `options` rather than `optoins`.
- Should read `connection` rather than `conenction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md